### PR TITLE
Turn on persistent undo

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -24,3 +24,8 @@ let ruby_fold=1               " Ruby
 let sh_fold_enabled=1         " sh
 let vimsyn_folding='af'       " Vim script
 let xml_syntax_folding=1      " XML
+
+" Turn on persistent undo
+" means: you can undo even after closing a buffer or even after closing vim
+set undodir=~/.vim/temp/undo
+set undofile


### PR DESCRIPTION
Mit persistent undo kannst du undo und redo benutzen, auch nachdem du einen vim buffer (oder gar vim selber) geschlossen hast. `u` fuer undo, `Ctrl-r` fuer redo. vim speichert die undo/redo Informationen in mehreren externen Dateien. Dafuer musst du den Pfad angeben, wo diese Informationen gespeichert werden sollen. Bei mir ist das im Directory `~/.vim/temp/undo`, ich habe bei dir mal dasselbe angegeben, kannst du aber natuerlich jederzeit aendern. vim wird sich wahrscheinlich beklagen, wenn das Verzeichnis nicht existiert. Deswegen braucht's ein `mkdir ~/.vim/temp/undo`.